### PR TITLE
feat: bump to .net 10

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/Microsoft.Configuration.Extensions.Tests/Microsoft.Configuration.Extensions.Tests.csproj
+++ b/Microsoft.Configuration.Extensions.Tests/Microsoft.Configuration.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -15,8 +15,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
+++ b/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Microsoft.Configuration.Extensions</PackageId>
-        <Version>9.0.0</Version>
+        <Version>10.0.0</Version>
         <Authors>bladehero</Authors>
         <PackageDescription>Custom Configuration Extensions</PackageDescription>
         <RepositoryUrl>https://github.com/bladehero/Microsoft.Configuration.Extensions</RepositoryUrl>
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Bumps the project from .NET 9 to .NET 10.

- Test project `TargetFramework`: `net9.0` → `net10.0`
- `Microsoft.Extensions.*` package references: `9.0.2` → `10.0.9` (library + tests)
- Library NuGet `Version`: `9.0.0` → `10.0.0`
- CI workflows (`build-and-test`, `publish`) `dotnet-version`: `9.0.x` → `10.0.x`

The main library continues to target `netstandard2.0` for broad compatibility — only package versions were updated there.

## Testing
- `dotnet build -c Release` → succeeds, 0 warnings / 0 errors
- `dotnet test -c Release` → all 8 tests pass on .NET 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)