### PR TITLE
feat: auto-derive package version from git tags via MinVer

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,9 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -28,4 +30,4 @@ jobs:
         run: dotnet pack --configuration Release --no-build -o ./out
 
       - name: Publish to NuGet
-        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json"
+        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate

--- a/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
+++ b/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Microsoft.Configuration.Extensions</PackageId>
-        <Version>10.0.0</Version>
+        <MinVerTagPrefix>v</MinVerTagPrefix>
         <Authors>bladehero</Authors>
         <PackageDescription>Custom Configuration Extensions</PackageDescription>
         <RepositoryUrl>https://github.com/bladehero/Microsoft.Configuration.Extensions</RepositoryUrl>
@@ -17,5 +17,9 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Stops hardcoding the NuGet package version in the csproj. The version is now derived automatically from git tags using [MinVer](https://github.com/adamralph/minver).

- Removed `<Version>` from the library `.csproj`
- Added `MinVer` (`PrivateAssets=all`, build-only — does not leak into package dependencies) and `<MinVerTagPrefix>v</MinVerTagPrefix>` to match the existing `v*.*.*` tag convention the publish workflow already triggers on
- CI now checks out full git history (`fetch-depth: 0`, `actions/checkout@v4`) so tags are visible to MinVer
- `dotnet nuget push` uses `--skip-duplicate` so re-runs/prerelease pushes don't fail

## How versioning works now
- **Release:** tag a commit `v10.0.1` and push the tag → package version `10.0.1`
- **Between tags:** untagged commits auto-produce an incrementing prerelease (e.g. `10.0.1-alpha.0.4`, where the trailing number is the commit height)

## Verified locally
- Temp tag `v10.0.0` on HEAD → `dotnet pack` produced `Microsoft.Configuration.Extensions.10.0.0.nupkg`
- No tags → produced `Microsoft.Configuration.Extensions.0.0.0-alpha.0.N.nupkg` (auto-increment)
- `dotnet build -c Release` clean (0 warnings), all 8 tests pass on net10.0

## Follow-up after merge
There are currently no version tags in the repo, so master builds will publish `0.0.0-alpha.*` prereleases until the first tag is created. To cut the stable 10.0.0 release, tag master:
```
git tag v10.0.0 && git push origin v10.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)