### PR TITLE
ci: publish to NuGet only on version tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,6 @@ name: Publish to NuGet
 
 on:
   push:
-    branches: ["master"]
     tags: ["v*.*.*"]
 
 jobs:


### PR DESCRIPTION
## Summary
Changes the publish workflow trigger so NuGet packages are published **only when a `v*.*.*` tag is pushed**, instead of on every push to `master`.

```diff
 on:
   push:
-    branches: ["master"]
     tags: ["v*.*.*"]
```

## Why
Paired with the MinVer tag-based versioning (#10), a release becomes an explicit, intentional action: tag a commit `v10.0.0` and push the tag to publish that exact version. Without this, every push to `master` would publish a `0.0.0-alpha.*` prerelease package.

## Notes
- Independent of #10 — touches a different part of `publish.yaml`, so the two PRs can merge in either order without conflict.
- After both are merged, the release flow is: `git tag v10.0.0 && git push origin v10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)