### PR TITLE
ci: auto-publish stable package on every merge to master

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,17 +2,20 @@ name: Publish to NuGet
 
 on:
   push:
-    tags: ["v*.*.*"]
+    branches: ["master"]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Auto-incrementing stable version: 10.0.<build>. Bump the 10.0 base here
+    # when you want a new major/minor; the patch increments on every run.
+    env:
+      VERSION: 10.0.${{ github.run_number }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -23,10 +26,10 @@ jobs:
         run: dotnet restore
 
       - name: Build the project
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore -p:Version=$VERSION
 
       - name: Pack the project
-        run: dotnet pack --configuration Release --no-build -o ./out
+        run: dotnet pack --configuration Release --no-build -o ./out -p:Version=$VERSION
 
       - name: Publish to NuGet
         run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate

--- a/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
+++ b/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
@@ -5,7 +5,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Microsoft.Configuration.Extensions</PackageId>
-        <MinVerTagPrefix>v</MinVerTagPrefix>
         <Authors>bladehero</Authors>
         <PackageDescription>Custom Configuration Extensions</PackageDescription>
         <RepositoryUrl>https://github.com/bladehero/Microsoft.Configuration.Extensions</RepositoryUrl>
@@ -17,9 +16,5 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Restores automatic publishing on every merge to `master`, with a **clean, auto-incrementing stable version** — no tags, no manual version edits.

- **Trigger:** publish workflow runs on `push: branches: ["master"]` again (was tags-only).
- **Version:** `10.0.${{ github.run_number }}` → `10.0.41`, `10.0.42`, `10.0.43`, … Set once in a job-level `env: VERSION` and passed to both `build` and `pack` so the assembly and package versions match.
- **Bumping major/minor:** change the `10.0` base in the workflow `env` block; the patch keeps auto-incrementing from the CI run number.

## Removes MinVer
MinVer is a *tag-driven, prerelease-between-tags* tool — the opposite of "stable version on every merge." Keeping it alongside this scheme would mean two competing version sources (with CI silently overriding MinVer), so it's removed:
- Dropped the `MinVer` package reference and `<MinVerTagPrefix>` from the library `.csproj`.
- Dropped `fetch-depth: 0` from both workflows (only needed so MinVer could see tags).

## Verified locally
- `dotnet build`/`dotnet pack -p:Version=10.0.42` → produces `Microsoft.Configuration.Extensions.10.0.42.nupkg`
- `dotnet test -c Release` → all 8 tests pass on net10.0

## Note
`github.run_number` is monotonic per-workflow and never resets, so versions always increase. It is **not** affected by which branch triggers the run, so the patch numbers will have gaps (only master pushes publish) — that's expected and harmless for ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)