### PR TITLE
ci: drive package version from the VERSION repo variable

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,10 +8,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-    # Auto-incrementing stable version: 10.0.<build>. Bump the 10.0 base here
-    # when you want a new major/minor; the patch increments on every run.
+    # Published version comes from the `VERSION` repository variable
+    # (Settings -> Secrets and variables -> Actions -> Variables). After a
+    # successful publish, the patch is incremented and written back to the
+    # variable. Edit the variable to set or jump the version (e.g. 10.1.0).
     env:
-      VERSION: 10.0.${{ github.run_number }}
+      VERSION: ${{ vars.VERSION }}
 
     steps:
       - name: Checkout code
@@ -33,3 +35,15 @@ jobs:
 
       - name: Publish to NuGet
         run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate
+
+      # Increment the patch and store it back in the VERSION variable so the
+      # next merge to master publishes the following version. Requires GH_PAT
+      # to have variable-write scope (classic `repo` or fine-grained Variables).
+      - name: Bump patch version for next run
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          next="$major.$minor.$((patch + 1))"
+          echo "Published $VERSION; setting VERSION variable to $next"
+          gh variable set VERSION --body "$next" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary
Replaces the `github.run_number`-based version (which GitHub owns and can't be reset) with a **repository variable `VERSION`** that we control. Each merge to `master` publishes the current value, then the workflow increments the patch and writes it back — gap-free, no commit-back to `master`.

- `env: VERSION: ${{ vars.VERSION }}` — single source of truth, editable in **Settings → Secrets and variables → Actions → Variables**.
- New **Bump** step after publish: `gh variable set VERSION` with `major.minor.(patch+1)`.
- The `VERSION` variable is already created with value **`10.0.1`**, so the first merge after this lands publishes `10.0.1`, then `10.0.2`, …
- To jump versions (e.g. a minor bump), just edit the variable to `10.1.0` in settings.

## Requirement (please verify)
The bump step authenticates with `secrets.GH_PAT`. The built-in `GITHUB_TOKEN` **cannot** manage Actions variables, so `GH_PAT` must have variable-write scope:
- classic PAT → `repo` scope, or
- fine-grained PAT → repository **Variables: Read and write**.

If `GH_PAT` is currently scoped only to `write:packages` for NuGet, the publish/pack steps still work but the **Bump** step will fail (the package still publishes; the variable just won't advance). Widen the token if so.

## Why this over the alternatives
- vs `run_number`: that counter is GitHub's, forcing offsets and leaving gaps. This value is ours.
- vs a version file + commit-back: no writes to `master`, so no branch-protection friction or bump commits in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)