### PR TITLE
test: cover IHostApplicationBuilder AddConfiguration overloads

### DIFF
--- a/Microsoft.Configuration.Extensions.Tests/ConfigurationExtensionsTests.cs
+++ b/Microsoft.Configuration.Extensions.Tests/ConfigurationExtensionsTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Configuration.Extensions.Tests;
@@ -91,6 +92,100 @@ public sealed class ConfigurationExtensionsTests
     }
 
     [Fact]
+    public void AddConfiguration_WhenHostBuilderWithTypeFromGenericArgument_ShouldProperlyAddConfiguration()
+    {
+        // Arrange
+        var builder = CreateHostApplicationBuilder();
+
+        // Act
+        var actual = builder
+            .AddConfiguration<SomeConfiguration>()
+            .Services.BuildServiceProvider()
+            .GetRequiredService<IOptions<SomeConfiguration>>()
+            .Value;
+
+        // Assert
+        actual.Should().BeEquivalentTo(ConfigurationShape);
+    }
+
+    [Fact]
+    public void AddConfiguration_WhenHostBuilderWithTypeFromGenericArgumentWithCustomSectionName_ShouldProperlyAddConfiguration()
+    {
+        // Arrange
+        var builder = CreateHostApplicationBuilder();
+
+        // Act
+        var actual = builder
+            .AddConfiguration<SomeConfiguration>(SectionName)
+            .Services.BuildServiceProvider()
+            .GetRequiredService<IOptions<SomeConfiguration>>()
+            .Value;
+
+        // Assert
+        actual.Should().BeEquivalentTo(ConfigurationShape);
+    }
+
+    [Fact]
+    public void AddConfiguration_WhenHostBuilderWithTypeIsMethodArgument_ShouldProperlyAddConfiguration()
+    {
+        // Arrange
+        var builder = CreateHostApplicationBuilder();
+
+        // Act
+        var actual = builder
+            .AddConfiguration(typeof(SomeConfiguration))
+            .Services.BuildServiceProvider()
+            .GetRequiredService<IOptions<SomeConfiguration>>()
+            .Value;
+
+        // Assert
+        actual.Should().BeEquivalentTo(ConfigurationShape);
+    }
+
+    [Fact]
+    public void AddConfiguration_WhenHostBuilderWithTypeIsMethodArgumentWithCustomSectionName_ShouldProperlyAddConfiguration()
+    {
+        // Arrange
+        var builder = CreateHostApplicationBuilder();
+
+        // Act
+        var actual = builder
+            .AddConfiguration(typeof(SomeConfiguration), SectionName)
+            .Services.BuildServiceProvider()
+            .GetRequiredService<IOptions<SomeConfiguration>>()
+            .Value;
+
+        // Assert
+        actual.Should().BeEquivalentTo(ConfigurationShape);
+    }
+
+    [Fact]
+    public void AddConfiguration_WhenHostBuilderWithTypeFromGenericArgument_ShouldReturnSameBuilder()
+    {
+        // Arrange
+        var builder = CreateHostApplicationBuilder();
+
+        // Act
+        var actual = builder.AddConfiguration<SomeConfiguration>();
+
+        // Assert
+        actual.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void AddConfiguration_WhenHostBuilderWithTypeIsMethodArgument_ShouldReturnSameBuilder()
+    {
+        // Arrange
+        var builder = CreateHostApplicationBuilder();
+
+        // Act
+        var actual = builder.AddConfiguration(typeof(SomeConfiguration));
+
+        // Assert
+        actual.Should().BeSameAs(builder);
+    }
+
+    [Fact]
     public void GetSectionAs_WhenNoSectionNameProvided_ShouldReturnByTypeName()
     {
         // Act
@@ -133,6 +228,13 @@ public sealed class ConfigurationExtensionsTests
 
         // Assert
         actual.Should().BeEquivalentTo(FirstNestedItem);
+    }
+
+    private static IHostApplicationBuilder CreateHostApplicationBuilder()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        builder.Configuration.AddInMemoryCollection(InMemorySettings);
+        return builder;
     }
 
     [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/Microsoft.Configuration.Extensions.Tests/Microsoft.Configuration.Extensions.Tests.csproj
+++ b/Microsoft.Configuration.Extensions.Tests/Microsoft.Configuration.Extensions.Tests.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/Microsoft.Configuration.Extensions/ConfigurationExtensions.cs
+++ b/Microsoft.Configuration.Extensions/ConfigurationExtensions.cs
@@ -15,19 +15,21 @@ public static class ConfigurationExtensions
         null
     )!;
 
-    public static IServiceCollection AddConfiguration<T>(this IHostApplicationBuilder builder, string? name = null)
+    public static IHostApplicationBuilder AddConfiguration<T>(this IHostApplicationBuilder builder, string? name = null)
         where T : class
     {
-        return builder.Services.AddConfiguration<T>(builder.Configuration, name);
+        builder.Services.AddConfiguration<T>(builder.Configuration, name);
+        return builder;
     }
 
-    public static IServiceCollection AddConfiguration(
+    public static IHostApplicationBuilder AddConfiguration(
         this IHostApplicationBuilder builder,
         Type type,
         string? name = null
     )
     {
-        return builder.Services.AddConfiguration(type, builder.Configuration, name);
+        builder.Services.AddConfiguration(type, builder.Configuration, name);
+        return builder;
     }
 
     public static IServiceCollection AddConfiguration<T>(


### PR DESCRIPTION
## Summary

- Make the generic `AddConfiguration<T>` and `Type`-based `AddConfiguration` host-builder overloads return `IHostApplicationBuilder` so they can be chained fluently.
- Add tests covering both overloads through a real `HostApplicationBuilder`.

## Tests

- Bind configuration via `Host.CreateEmptyApplicationBuilder` for the generic and `Type` overloads, with default and custom section names, asserting the resolved `IOptions<T>` value matches the expected shape.
- Assert each overload returns the same builder instance to lock in the fluent contract.
- Added the `Microsoft.Extensions.Hosting` package to the test project to construct a real builder, consistent with the existing tests using real components instead of mocks.

All 14 tests pass.