### PR TITLE
ci: publish to nuget.org and rename package to Bladehero prefix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,8 +33,11 @@ jobs:
       - name: Pack the project
         run: dotnet pack --configuration Release --no-build -o ./out -p:Version=$VERSION
 
-      - name: Publish to NuGet
+      - name: Publish to GitHub Packages
         run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate
+
+      - name: Publish to NuGet.org
+        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
 
       # Increment the patch and store it back in the VERSION variable so the
       # next merge to master publishes the following version. Requires GH_PAT

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Trusted Publishing to nuget.org exchanges a GitHub OIDC token for a
+    # short-lived API key, so the job needs id-token write permission.
+    # contents:read keeps the default GITHUB_TOKEN at least-privilege (the
+    # version-bump step authenticates separately via GH_PAT).
+    permissions:
+      id-token: write
+      contents: read
+
     # Published version comes from the `VERSION` repository variable
     # (Settings -> Secrets and variables -> Actions -> Variables). After a
     # successful publish, the patch is incremented and written back to the
@@ -36,8 +44,18 @@ jobs:
       - name: Publish to GitHub Packages
         run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate
 
+      # nuget.org Trusted Publishing (OIDC): exchange the job's OIDC token for a
+      # short-lived API key — no long-lived secret is stored. Requires a trusted
+      # publishing policy on nuget.org bound to this repo + workflow, and the
+      # `NUGET_USER` repo variable set to the nuget.org account owning the policy.
+      - name: Log in to NuGet.org (trusted publishing)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       - name: Publish to NuGet.org
-        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+        run: dotnet nuget push ./out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
 
       # Increment the patch and store it back in the VERSION variable so the
       # next merge to master publishes the following version. Requires GH_PAT

--- a/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
+++ b/Microsoft.Configuration.Extensions/Microsoft.Configuration.Extensions.csproj
@@ -4,12 +4,19 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageId>Microsoft.Configuration.Extensions</PackageId>
+        <PackageId>Bladehero.Configuration.Extensions</PackageId>
         <Authors>bladehero</Authors>
         <PackageDescription>Custom Configuration Extensions</PackageDescription>
         <RepositoryUrl>https://github.com/bladehero/Microsoft.Configuration.Extensions</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />


### PR DESCRIPTION
## Why

Publish the package to the public nuget.org feed and make the whole project consistently carry the `Bladehero` identity (the `Microsoft.` name was misleading and is a reserved nuget.org prefix).

## Changes

- **Renamed the project identity** `Microsoft.Configuration.Extensions` → `Bladehero.Configuration.Extensions`: `PackageId`, assembly name, root namespace, both project files + directories, and the solution. Only the project''s own identifiers changed — the `Microsoft.Extensions.*` package dependencies are untouched.
- Added package metadata for a complete public listing: `PackageLicenseExpression` (MIT, matches the repo `LICENSE`), bundled `README.md`, and `PublishRepositoryUrl`; pointed `RepositoryUrl` at the renamed GitHub repo.
- **`publish.yaml`**: kept the GitHub Packages push and added a push to `https://api.nuget.org/v3/index.json` using **Trusted Publishing (OIDC)** — `NuGet/login@v1` exchanges the job''s GitHub OIDC token for a short-lived key at runtime. No long-lived `NUGET_API_KEY` secret is stored. The `VERSION`-variable auto-increment flow is unchanged.

## ⚠️ Breaking change

The namespace is now `Bladehero.Configuration.Extensions`. Consumers must update their using directive to `using Bladehero.Configuration.Extensions;`.

## Required before this works

1. **Create a Trusted Publishing policy on nuget.org**: sign in → username menu → **Trusted Publishing** → add a policy bound to repository owner `bladehero`, repository `Bladehero.Configuration.Extensions`, and workflow `publish.yaml`.
2. The `NUGET_USER` repo variable is set to the nuget.org account username (`bladehero`). No `NUGET_API_KEY` secret is needed.
3. Optionally reserve the `Bladehero.*` ID prefix on nuget.org after the first publish.

## Verification

- `dotnet test`: 14/14 pass after the rename.
- `dotnet pack`: produces `Bladehero.Configuration.Extensions.<version>.nupkg` containing `lib/netstandard2.0/Bladehero.Configuration.Extensions.dll`, MIT license, and README — no metadata warnings.